### PR TITLE
[PoC] Change LogExplorerTabs to persist current tab state instead of state sharing

### DIFF
--- a/src/plugins/discover/public/components/log_explorer_tabs/index.ts
+++ b/src/plugins/discover/public/components/log_explorer_tabs/index.ts
@@ -9,6 +9,10 @@
 import { withSuspense } from '@kbn/shared-ux-utility';
 import { lazy } from 'react';
 
-export type { LogExplorerTabsParams, LogExplorerTabsProps } from './log_explorer_tabs';
+export type {
+  LogExplorerTabsParams,
+  LogExplorerTabsProps,
+  LogExplorerTab,
+} from './log_explorer_tabs';
 
 export const LogExplorerTabs = withSuspense(lazy(() => import('./log_explorer_tabs')));

--- a/src/plugins/discover/public/index.ts
+++ b/src/plugins/discover/public/index.ts
@@ -38,4 +38,5 @@ export {
   LogExplorerTabs,
   type LogExplorerTabsParams,
   type LogExplorerTabsProps,
+  type LogExplorerTab,
 } from './components/log_explorer_tabs';


### PR DESCRIPTION
## Summary

WIP.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)